### PR TITLE
Implementation for /sensor/setIgnore and depending changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ API
       ;
 
     cloud = new TelldusAPI.TelldusAPI({ publicKey  : publicKey
-                                      , privateKey : privateKey }).login(function(token, tokenSecret, function(err, user)) {
+                                      , privateKey : privateKey }).login(token, tokenSecret, function(err, user) {
       if (!!err) return console.log('login error: ' + err.message);
 
       // otherwise, good to go!
@@ -107,7 +107,7 @@ API
 
 ### Get sensor information
 
-    cloud.getSensors(function(err, sensors) {
+    cloud.getSensors(/*optional paramsObject{}, */function(err, sensors) {
       if (!!err) return console.log('getSensors: ' + err.message);
 
       // inspect sensors[{}]
@@ -122,6 +122,9 @@ API
 ### Modify sensor
 
     cloud.setSensorName(sensor, name, function(err, result) {
+    });
+
+    cloud.setSensorIgnore(sensor, ignore, function(err, result) {
     });
 
 

--- a/telldus-live.js
+++ b/telldus-live.js
@@ -53,8 +53,12 @@ TelldusAPI.prototype.login = function(token, tokenSecret, callback) {
 };
 
 
-TelldusAPI.prototype.getSensors = function(callback) {
-  return this.roundtrip('GET', '/sensors/list', function(err, results) {
+TelldusAPI.prototype.getSensors = function(params, callback) {
+  if ((!callback) && (typeof params === 'function')) {
+    callback = params;
+    params = null;
+  }
+  return this.roundtrip('GET', '/sensors/list?' + querystring.stringify(params), function(err, results) {
     if (!!err) return callback(err);
 
     if (!util.isArray(results.sensor)) return callback(new Error('non-array returned: ' + JSON.stringify(results)));
@@ -71,6 +75,11 @@ TelldusAPI.prototype.setSensorName = function(sensor, name, callback) {
                                                                               , name      : name }), callback);
 };
 
+TelldusAPI.prototype.setSensorIgnore = function(sensor, ignore, callback) {
+  return this.roundtrip('PUT', '/sensor/setIgnore?' + querystring.stringify(    { id        : sensor.id
+                                                                              , ignore      : ignore }), callback);
+  
+};
 
 exports.commands = { on   : 0x0001
                    , off  : 0x0002


### PR DESCRIPTION
With the suggested implementation of ignoring sensors we need to be able to include ignored sensors with the **getSensors** call. To not break backwards compability I added an optional params object.
i.e. both of the below works to maintain backwards compability

`getSensors(function(err, sensors) { });`
or with the new optional params object
`getSensors({includeIgnored: 1}, function(err, sensors) { });`

the new **setSensorIgnore** block is straightforward with two parameters and the callback.